### PR TITLE
Add more default headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ As a standalone plugin, you can use the following constants to change the behavi
 * `ABS_AUTOMATIC_INTEGRITY` (`bool`): True to enable automatic generation of integrity hashes, false to disable. (True by default.)
 * `ABS_NOSNIFF_HEADER` (`bool`): True to send `X-Content-Type-Options: nosniff`, false to disable. (True by default.)
 * `ABS_FRAME_OPTIONS_HEADER` (`bool`): True to send `X-Frame-Options: SAMEORIGIN`, false to disable. (True by default.)
+* `ABS_XSS_PROTECTION_HEADER` (`bool`): True to send ``X-XSS-Protection: 1; mode=block`, false to disable. (True by default.)
 
 
 ## Features
@@ -81,6 +82,17 @@ define( 'ABS_FRAME_OPTIONS_HEADER', false );
 ```
 
 You can then send your own headers as needed. We recommend hooking into the `template_redirect` hook to send these headers.
+
+
+#### X-XSS-Protection
+
+By default, Altis adds a [`X-XSS-Protection` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection?) with the value set to `1; mode=block`. This prevents browsers from loading if they detect [cross-site scripting (XSS) attacks](https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)).
+
+This should generally always be sent. If you need to disable it, set the `ABS_XSS_PROTECTION_HEADER` header:
+
+```php
+define( 'ABS_XSS_PROTECTION_HEADER', false );
+```
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ If you are using this as part of the [Altis DXP](https://www.altis-dxp.com/), co
 As a standalone plugin, you can use the following constants to change the behaviour of this module:
 
 * `ABS_AUTOMATIC_INTEGRITY` (`bool`): True to enable automatic generation of integrity hashes, false to disable. (True by default.)
+* `ABS_NOSNIFF_HEADER` (`bool`): True to send `X-Content-Type-Options: nosniff`, false to disable. (True by default.)
+* `ABS_FRAME_OPTIONS_HEADER` (`bool`): True to send `X-Frame-Options: SAMEORIGIN`, false to disable. (True by default.)
 
 
 ## Features
@@ -48,6 +50,37 @@ use function Altis\Security\Browser\set_hash_for_style;
 wp_enqueue_style( 'my-handle', 'https://...' );
 set_hash_for_style( 'my-handle', 'sha384-...' );
 ```
+
+
+### Security Headers
+
+This plugin automatically adds various security headers by default. These follow best-practices for web security and aim to provide a sensible, secure default.
+
+In some cases, you may want to adjust or disable these headers depending on the use cases of your site.
+
+
+#### X-Content-Type-Options
+
+By default, Altis adds a [`X-Content-Type-Options` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options) with the value set to `nosniff`. This prevents browsers from attempting to guess the content type based on the content, and instead forces them to follow the type set in the `Content-Type` header.
+
+This should generally always be sent, and your content type should always be set explicitly. If you need to disable it, set the `ABS_NOSNIFF_HEADER` constant:
+
+```php
+define( 'ABS_NOSNIFF_HEADER', false );
+```
+
+
+#### X-Frame-Options
+
+By default, Altis adds a [`X-Frame-Options` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) with the value set to `sameorigin`. This prevents your site from being iframed into another site, which can prevent [clickjacking attacks](https://en.wikipedia.org/wiki/Clickjacking).
+
+This should generally always be sent, but in some cases, you may want to allow specific sites to iframe your site, or allow any sites. To disable the automatic header, set the `ABS_FRAME_OPTIONS_HEADER` constant:
+
+```php
+define( 'ABS_FRAME_OPTIONS_HEADER', false );
+```
+
+You can then send your own headers as needed. We recommend hooking into the `template_redirect` hook to send these headers.
 
 
 ## License

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -23,6 +23,14 @@ function bootstrap( array $config ) {
 		add_filter( 'style_loader_tag', __NAMESPACE__ . '\\generate_hash_for_style', 0, 3 );
 	}
 
+	if ( $config['nosniff-header'] ?? true ) {
+		add_action( 'template_redirect', 'send_nosniff_header' );
+	}
+
+	if ( $config['frame-options-header'] ?? true ) {
+		add_action( 'template_redirect', 'send_frame_options_header' );
+	}
+
 	add_filter( 'script_loader_tag', __NAMESPACE__ . '\\output_integrity_for_script', 0, 2 );
 	add_filter( 'style_loader_tag', __NAMESPACE__ . '\\output_integrity_for_style', 0, 3 );
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -31,6 +31,10 @@ function bootstrap( array $config ) {
 		add_action( 'template_redirect', 'send_frame_options_header' );
 	}
 
+	if ( $config['xss-protection-header'] ?? true ) {
+		add_action( 'template_redirect', __NAMESPACE__ . '\\send_xss_header' );
+	}
+
 	add_filter( 'script_loader_tag', __NAMESPACE__ . '\\output_integrity_for_script', 0, 2 );
 	add_filter( 'style_loader_tag', __NAMESPACE__ . '\\output_integrity_for_style', 0, 3 );
 
@@ -340,4 +344,16 @@ function output_integrity_for_style( string $html, string $handle ) : string {
 		$html
 	);
 	return $html;
+}
+
+/**
+ * Send XSS protection header for legacy browsers.
+ *
+ * This is deprecated, but some browsers still want it. Additionally, this is
+ * often tested in automated security checks.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
+ */
+function send_xss_header() {
+	header( 'X-XSS-Protection: 1; mode=block' );
 }

--- a/plugin.php
+++ b/plugin.php
@@ -15,4 +15,6 @@ if ( function_exists( 'Altis\\Security\\bootstrap' ) ) {
 
 bootstrap( [
 	'automatic-integrity' => defined( 'ABS_AUTOMATIC_INTEGRITY' ) ? ABS_AUTOMATIC_INTEGRITY : true,
+	'nosniff-header' => defined( 'ABS_NOSNIFF_HEADER' ) ? ABS_NOSNIFF_HEADER : true,
+	'frame-options-header' => defined( 'ABS_FRAME_OPTIONS_HEADER' ) ? ABS_FRAME_OPTIONS_HEADER : true,
 ] );

--- a/plugin.php
+++ b/plugin.php
@@ -17,4 +17,5 @@ bootstrap( [
 	'automatic-integrity' => defined( 'ABS_AUTOMATIC_INTEGRITY' ) ? ABS_AUTOMATIC_INTEGRITY : true,
 	'nosniff-header' => defined( 'ABS_NOSNIFF_HEADER' ) ? ABS_NOSNIFF_HEADER : true,
 	'frame-options-header' => defined( 'ABS_FRAME_OPTIONS_HEADER' ) ? ABS_FRAME_OPTIONS_HEADER : true,
+	'xss-protection-header' => defined( 'ABS_XSS_PROTECTION_HEADER' ) ? ABS_XSS_PROTECTION_HEADER :true,
 ] );


### PR DESCRIPTION
Adds further headers that are good to set by default. These are all fairly unopinionated, and can generally be left turned on for most people; only the X-Frame-Options will need configuring by anyone in 99.99999% of cases I imagine.

Requires #3.