### PR TITLE
Add Content-Security-Policy framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ set_hash_for_style( 'my-handle', 'sha384-...' );
 
 ### Content-Security-Policy
 
-This plugin can automatically gather and send [Content-Security-Policy policies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) for you automatically.
+This plugin can gather and send [Content-Security-Policy policies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) for you automatically.
 
 Out of the box, no policies are sent.
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ add_filter( 'altis.security.browser.filter_policy_value', function ( array $valu
 } );
 ```
 
+To build Content-Security-Policy policies, we recommend using the [Laboratory CSP toolkit extension](https://addons.mozilla.org/en-US/firefox/addon/laboratory-by-mozilla/) for Firefox, and the [CSP Evaluator tool](https://csp-evaluator.withgoogle.com/).
+
 
 ### Security Headers
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ add_filter( 'altis.security.browser.content_security_policies', function ( array
 } );
 ```
 
-Special directives (`'self'`, `'unsafe-inline'`, `'unsafe-eval'`, `'none'`, `'strict-dynamic'`) are handled specially and do not need to be quoted.
+Special directives (`'self'`, `'unsafe-inline'`, `'unsafe-eval'`, `'none'`, `'strict-dynamic'`) do not need to be double-quoted.
 
 You can also modify individual directives if desired:
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ set_hash_for_style( 'my-handle', 'sha384-...' );
 
 This plugin can gather and send [Content-Security-Policy policies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) for you automatically.
 
-Out of the box, no policies are sent.
+**Out of the box, no policies are sent.** CSP policies tend to be specific to sites, so no assumptions are made about what you may want.
 
 Add a filter to `altis.security.browser.content_security_policies` to set policies. This filter receives an array, where the keys are the policy directive names. Each item can either be a string or a list of directive value strings:
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,58 @@ set_hash_for_style( 'my-handle', 'sha384-...' );
 ```
 
 
+### Content-Security-Policy
+
+This plugin can automatically gather and send [Content-Security-Policy policies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) for you automatically.
+
+Out of the box, no policies are sent.
+
+Add a filter to `altis.security.browser.content_security_policies` to set policies. This filter receives an array, where the keys are the policy directive names. Each item can either be a string or a list of directive value strings:
+
+```php
+add_filter( 'altis.security.browser.content_security_policies', function ( array $policies ) : array {
+	// Policies can be set as strings.
+	$policies['object-src'] = 'none';
+	$policies['base-uri'] = 'self';
+
+	// Policies can also be set as arrays.
+	$policies['font-src'] = [
+		'https://fonts.gstatic.com',
+		'https://cdnjs.cloudflare.com',
+	];
+
+	// Special directives (such as `unsafe-inline`) are handled for you.
+	$policies['script-src'] = [
+		'https:',
+		'unsafe-inline',
+	];
+
+	return $policies;
+} );
+```
+
+Special directives (`'self'`, `'unsafe-inline'`, `'unsafe-eval'`, `'none'`, `'strict-dynamic'`) are handled specially and do not need to be quoted.
+
+You can also modify individual directives if desired:
+
+```php
+// You can filter specific keys via the filter name.
+add_filter( 'altis.security.browser.filter_policy_value.font-src', function ( array $values ) : array {
+	$values[] = 'https://fonts.gstatic.com';
+	return $values;
+} );
+
+// A filter is also available with the directive name in a parameter.
+add_filter( 'altis.security.browser.filter_policy_value', function ( array $values, string $name ) : array {
+	if ( $name === 'font-src' ) {
+		$values[] = 'https://cdnjs.cloudflare.com';
+	}
+
+	return $values;
+} );
+```
+
+
 ### Security Headers
 
 This plugin automatically adds various security headers by default. These follow best-practices for web security and aim to provide a sensible, secure default.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -37,6 +37,7 @@ function bootstrap( array $config ) {
 
 	add_filter( 'script_loader_tag', __NAMESPACE__ . '\\output_integrity_for_script', 0, 2 );
 	add_filter( 'style_loader_tag', __NAMESPACE__ . '\\output_integrity_for_style', 0, 3 );
+	add_action( 'template_redirect', __NAMESPACE__ . '\\send_csp_header' );
 
 	// Register cache group as global (as it's path-based rather than data-based).
 	wp_cache_add_global_groups( INTEGRITY_CACHE_GROUP );
@@ -356,4 +357,104 @@ function output_integrity_for_style( string $html, string $handle ) : string {
  */
 function send_xss_header() {
 	header( 'X-XSS-Protection: 1; mode=block' );
+}
+
+/**
+ * Filter an individual policy value.
+ *
+ * @param string $name Directive name.
+ * @param string|array $value Directive value.
+ * @return string[] List of directive values.
+ */
+function filter_policy_value( string $name, $value ) : array {
+	$value = (array) $value;
+
+	$needs_quotes = [
+		'self',
+		'unsafe-inline',
+		'unsafe-eval',
+		'none',
+		'strict-dynamic',
+	];
+
+	// Normalize directive values.
+	foreach ( $value as &$item ) {
+		if ( in_array( $item, $needs_quotes, true ) || strpos( $item, 'nonce-' ) === 0 ) {
+			// Add missing quotes if the value was erroneously added
+			// without them.
+			$item = sprintf( "'%s'", $item );
+		}
+	}
+
+	/**
+	 * Filter value for a given policy directive.
+	 *
+	 * `$name` is the directive name.
+	 *
+	 * @param array $value List of directive values.
+	 */
+	$value = apply_filters( "altis.security.browser.filter_policy_value.$name", $value );
+
+	/**
+	 * Filter value for a given policy directive.
+	 *
+	 * @param array $value List of directive values.
+	 * @param string $name Directive name.
+	 */
+	return apply_filters( 'altis.security.browser.filter_policy_value', $value, $name );
+}
+
+/**
+ * Send the Content-Security-Policy header.
+ *
+ * The header is only sent if policies have been specified. See
+ * get_content_security_policies() for setting the policies.
+ */
+function send_csp_header() {
+	// Gather and filter the policy parts.
+	$policies = get_content_security_policies();
+	$policy_parts = [];
+	foreach ( $policies as $key => $value ) {
+		$value = filter_policy_value( $key, $value );
+		if ( empty( $value ) ) {
+			continue;
+		}
+		$policy_parts[] = sprintf( '%s %s', $key, implode( ' ', $value ) );
+	}
+	if ( empty( $policy_parts ) ) {
+		return;
+	}
+
+	header( 'Content-Security-Policy: ' . implode( '; ', $policy_parts ) );
+}
+
+/**
+ * Get the content security policies for the current page.
+ *
+ * @return array Map from directive name to value or list of values.
+ */
+function get_content_security_policies() : array {
+	$policies = [
+		'child-src' => [],
+		'font-src' => [],
+		'frame-src' => [],
+		'img-src' => [],
+		'media-src' => [],
+		'object-src' => [],
+		'script-src' => [],
+		'style-src' => [],
+	];
+
+	/**
+	 * Filter the security policies for the current page.
+	 *
+	 * The filtered value is a map from directive name (e.g. `base-uri`,
+	 * `default-src`) to directive value. Each directive value can be a string
+	 * or list of strings.
+	 *
+	 * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+	 *
+	 * @param string[] $policies Map from directive name to value or list of values.
+	 */
+	return apply_filters( 'altis.security.browser.content_security_policies', $policies );
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -35,6 +35,12 @@ function bootstrap( array $config ) {
 		add_action( 'template_redirect', __NAMESPACE__ . '\\send_xss_header' );
 	}
 
+	if ( $config['content-security-policy'] ?? null ) {
+		add_filter( 'altis.security.browser.content_security_policies', function ( $policies ) use ( $config ) {
+			return array_merge( $policies, $config['content-security-policy'] );
+		}, 0 );
+	}
+
 	add_filter( 'script_loader_tag', __NAMESPACE__ . '\\output_integrity_for_script', 0, 2 );
 	add_filter( 'style_loader_tag', __NAMESPACE__ . '\\output_integrity_for_style', 0, 3 );
 	add_action( 'template_redirect', __NAMESPACE__ . '\\send_csp_header' );


### PR DESCRIPTION
Adds a framework for content-security-policy headers.

For the full module integration, the default can be configured via composer.json, and the filters can override on a per-page level. As a standalone plugin, only the filters will work, as you can't set arrays in constants.