### PR TITLE
Implement report only policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+services:
+  - docker
+
+before_script:
+  - composer install
+
+script:
+  composer test

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ add_filter( 'altis.security.browser.filter_policy_value', function ( array $valu
 
 To build Content-Security-Policy policies, we recommend using the [Laboratory CSP toolkit extension](https://addons.mozilla.org/en-US/firefox/addon/laboratory-by-mozilla/) for Firefox, and the [CSP Evaluator tool](https://csp-evaluator.withgoogle.com/).
 
+#### Report-Only Policies
+
+To send a [Content-Security-Policy-Report-Only header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only), use the exact same process described above for the ordinary CSP policies with the alternative `altis.security.browser.report_only_content_security_policies` filter. Both normal and report-only policies may be used simultaneously.
+
 
 ### Security Headers
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ To build Content-Security-Policy policies, we recommend using the [Laboratory CS
 
 #### Report-Only Policies
 
-To send a [Content-Security-Policy-Report-Only header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only), use the exact same process described above for the ordinary CSP policies with the alternative filter `altis.security.browser.report_only_content_security_policies`. An external service must be used to ingest the reports from the Report-Only policies. The external service will provide you with a reporting URL which can then be defined by adding a `report-uri` directive with the appropriate URL for processing reports.
+To send a [Content-Security-Policy-Report-Only header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only), use the exact same process described above for the ordinary CSP policies with the alternative filter `altis.security.browser.report_only_content_security_policies`.
+
+An external service must be used to ingest the reports from Report-Only policies. The external service will provide you with a reporting URL which you can use by adding a `report-uri` directive with the appropriate URL for processing reports.
 
 You can also modify individual directives for use in report-only policies in the same manner described above using the filters,
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ To build Content-Security-Policy policies, we recommend using the [Laboratory CS
 
 #### Report-Only Policies
 
-To send a [Content-Security-Policy-Report-Only header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only), use the exact same process described above for the ordinary CSP policies with the alternative `altis.security.browser.report_only_content_security_policies` filter. Both normal and report-only policies may be used simultaneously.
+To send a [Content-Security-Policy-Report-Only header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only), use the exact same process described above for the ordinary CSP policies with the alternative filter `altis.security.browser.report_only_content_security_policies`.
+
+Both normal and report-only policies may be used simultaneously.
 
 
 ### Security Headers

--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ To send a [Content-Security-Policy-Report-Only header](https://developer.mozilla
 
 An external service must be used to ingest the reports from Report-Only policies. The external service will provide you with a reporting URL which you can use by adding a `report-uri` directive with the appropriate URL for processing reports.
 
+As an example, you can add a reporting directive to your Report-Only policies by filtering the policies array:
+```php
+add_filter( 'altis.security.browser.report_only_content_security_policies', function ( array $policies ) : array {
+	$policies['report-uri'] = 'https://example.uriports.com/reports';
+	return $policies;
+} );
+
 You can also modify individual directives for use in report-only policies in the same manner described above using the filters,
 
 - `altis.security.browser.filter_report_only_policy_value.{ directive name }`

--- a/README.md
+++ b/README.md
@@ -113,11 +113,13 @@ To send a [Content-Security-Policy-Report-Only header](https://developer.mozilla
 An external service must be used to ingest the reports from Report-Only policies. The external service will provide you with a reporting URL which you can use by adding a `report-uri` directive with the appropriate URL for processing reports.
 
 As an example, you can add a reporting directive to your Report-Only policies by filtering the policies array:
+
 ```php
 add_filter( 'altis.security.browser.report_only_content_security_policies', function ( array $policies ) : array {
 	$policies['report-uri'] = 'https://example.uriports.com/reports';
 	return $policies;
 } );
+```
 
 You can also modify individual directives for use in report-only policies in the same manner described above using the filters,
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ As a standalone plugin, you can use the following constants to change the behavi
 * `ABS_AUTOMATIC_INTEGRITY` (`bool`): True to enable automatic generation of integrity hashes, false to disable. (True by default.)
 * `ABS_NOSNIFF_HEADER` (`bool`): True to send `X-Content-Type-Options: nosniff`, false to disable. (True by default.)
 * `ABS_FRAME_OPTIONS_HEADER` (`bool`): True to send `X-Frame-Options: SAMEORIGIN`, false to disable. (True by default.)
-* `ABS_XSS_PROTECTION_HEADER` (`bool`): True to send ``X-XSS-Protection: 1; mode=block`, false to disable. (True by default.)
+* `ABS_XSS_PROTECTION_HEADER` (`bool`): True to send `X-XSS-Protection: 1; mode=block`, false to disable. (True by default.)
 
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ To build Content-Security-Policy policies, we recommend using the [Laboratory CS
 
 To send a [Content-Security-Policy-Report-Only header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only), use the exact same process described above for the ordinary CSP policies with the alternative filter `altis.security.browser.report_only_content_security_policies`.
 
+You can also modify individual directives for use in report-only policies in the same manner described above using the filters,
+
+- `altis.security.browser.filter_report_only_policy_value.{ directive name }`
+- `altis.security.browser.filter_report_only_policy_value`
+
 Both normal and report-only policies may be used simultaneously.
 
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ To build Content-Security-Policy policies, we recommend using the [Laboratory CS
 
 #### Report-Only Policies
 
-To send a [Content-Security-Policy-Report-Only header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only), use the exact same process described above for the ordinary CSP policies with the alternative filter `altis.security.browser.report_only_content_security_policies`.
+To send a [Content-Security-Policy-Report-Only header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only), use the exact same process described above for the ordinary CSP policies with the alternative filter `altis.security.browser.report_only_content_security_policies`. An external service must be used to ingest the reports from the Report-Only policies. The external service will provide you with a reporting URL which can then be defined by adding a `report-uri` directive with the appropriate URL for processing reports.
 
 You can also modify individual directives for use in report-only policies in the same manner described above using the filters,
 

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,11 @@
         "files": [
             "inc/namespace.php"
         ]
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7.5"
+    },
+    "scripts": {
+        "test": "docker run --rm -v \"$PWD:/code\" humanmade/plugin-tester"
     }
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -375,11 +375,13 @@ function send_xss_header() {
 /**
  * Filter an individual policy value.
  *
- * @param string $name Directive name.
- * @param string|array $value Directive value.
+ * @param string       $name        Directive name.
+ * @param string|array $value       Directive value.
+ * @param bool         $report_only Whether the directive is being filtered for
+ *                                  use in a Report-Only policy. (False by default.)
  * @return string[] List of directive values.
  */
-function filter_policy_value( string $name, $value ) : array {
+function filter_policy_value( string $name, $value, bool $report_only = false ) : array {
 	$value = (array) $value;
 
 	$needs_quotes = [
@@ -397,6 +399,25 @@ function filter_policy_value( string $name, $value ) : array {
 			// without them.
 			$item = sprintf( "'%s'", $item );
 		}
+	}
+
+	if ( $report_only ) {
+		/**
+		 * Filter value for a given report-only policy directive.
+		 *
+		 * `$name` is the directive name.
+		 *
+		 * @param array $value List of directive values.
+		 */
+		$value = apply_filters( "altis.security.browser.filter_report_only_policy_value.$name", $value );
+	
+		/**
+		 * Filter value for a given report-only policy directive.
+		 *
+		 * @param array $value List of directive values.
+		 * @param string $name Directive name.
+		 */
+		return apply_filters( 'altis.security.browser.filter_report_only_policy_value', $value, $name );
 	}
 
 	/**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -43,7 +43,8 @@ function bootstrap( array $config ) {
 
 	add_filter( 'script_loader_tag', __NAMESPACE__ . '\\output_integrity_for_script', 0, 2 );
 	add_filter( 'style_loader_tag', __NAMESPACE__ . '\\output_integrity_for_style', 0, 3 );
-	add_action( 'template_redirect', __NAMESPACE__ . '\\send_csp_header' );
+	add_action( 'template_redirect', __NAMESPACE__ . '\\send_normal_csp_header' );
+	add_action( 'template_redirect', __NAMESPACE__ . '\\send_report_only_csp_header' );
 
 	// Register cache group as global (as it's path-based rather than data-based).
 	wp_cache_add_global_groups( INTEGRITY_CACHE_GROUP );
@@ -416,9 +417,37 @@ function filter_policy_value( string $name, $value ) : array {
  * The header is only sent if policies have been specified. See
  * get_content_security_policies() for setting the policies.
  */
-function send_csp_header() {
+function send_normal_csp_header() {
 	// Gather and filter the policy parts.
 	$policies = get_content_security_policies();
+	send_csp_header( 'Content-Security-Policy', $policies );
+}
+
+/**
+ * Send the Content-Security-Policy-Report-Only header.
+ *
+ * The header is only sent if policies have been specified. See
+ * get_report_only_content_security_policies() for setting the policies.
+ */
+function send_report_only_csp_header() {
+	// Gather and filter the report-only policy parts.
+	$policies = get_report_only_content_security_policies();
+	send_csp_header( 'Content-Security-Policy-Report-Only', $policies );
+}
+
+/**
+ * Send the Content-Security-Policy or Content-Security-Policy-Report-Only headers.
+ *
+ * The header is only sent if policies have been specified. See
+ * get_content_security_policies() and get_report_only_content_security_policies()
+ * for setting the policies.
+ *
+ * @param string[] $policies The policies to apply for the specified header.
+ * @param string   $header   One of 'Content-Security-Policy' or
+ *                           'Content-Security-Policy-Report-Only'.
+ * @return void Sends CSP header and exits.
+ */
+function send_csp_header( string $header, array $policies ) {
 	$policy_parts = [];
 	foreach ( $policies as $key => $value ) {
 		$value = filter_policy_value( $key, $value );
@@ -431,16 +460,16 @@ function send_csp_header() {
 		return;
 	}
 
-	header( 'Content-Security-Policy: ' . implode( '; ', $policy_parts ) );
+	header( $header . ': ' . implode( '; ', $policy_parts ) );
 }
 
 /**
- * Get the content security policies for the current page.
+ * Return an array of CSP directives for use in CSP and CSP-Report-Only headers.
  *
- * @return array Map from directive name to value or list of values.
+ * @return array Map of directive names to empty arrays.
  */
-function get_content_security_policies() : array {
-	$policies = [
+function get_content_security_policy_directives() : array {
+	return [
 		'child-src' => [],
 		'font-src' => [],
 		'frame-src' => [],
@@ -450,6 +479,15 @@ function get_content_security_policies() : array {
 		'script-src' => [],
 		'style-src' => [],
 	];
+}
+
+/**
+ * Get the content security policies for the current page.
+ *
+ * @return array Map from directive name to value or list of values.
+ */
+function get_content_security_policies() : array {
+	$policies = get_content_security_policy_directives();
 
 	/**
 	 * Filter the security policies for the current page.
@@ -463,4 +501,26 @@ function get_content_security_policies() : array {
 	 * @param string[] $policies Map from directive name to value or list of values.
 	 */
 	return apply_filters( 'altis.security.browser.content_security_policies', $policies );
+}
+
+/**
+ * Get the content security policies for the current page.
+ *
+ * @return array Map from directive name to value or list of values.
+ */
+function get_report_only_content_security_policies() : array {
+	$policies = get_content_security_policy_directives();
+
+	/**
+	 * Filter the report-only security policies for the current page.
+	 *
+	 * The filtered value is a map from directive name (e.g. `base-uri`,
+	 * `default-src`) to directive value. Each directive value can be a
+	 * string or array of strings.
+	 *
+	 * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
+	 *
+	 * @param string[] $policies Map from directive name to value or list of values.
+	 */
+	return apply_filters( 'altis.security.browser.report_only_content_security_policies', $policies );
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -475,9 +475,10 @@ function send_report_only_csp_header() {
  * @return void Sends CSP header and exits.
  */
 function send_csp_header( string $header, array $policies ) {
+	$report_only = $header === 'Content-Security-Policy-Report-Only';
 	$policy_parts = [];
 	foreach ( $policies as $key => $value ) {
-		$value = filter_policy_value( $key, $value );
+		$value = filter_policy_value( $key, $value, $report_only );
 		if ( empty( $value ) ) {
 			continue;
 		}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -41,6 +41,12 @@ function bootstrap( array $config ) {
 		}, 0 );
 	}
 
+	if ( $config['report-only-content-security-policy'] ?? null ) {
+		add_filter( 'altis.security.browser.report_only_content_security_policies', function ( $policies ) use ( $config ) {
+			return array_merge( $policies, $config['report-only-content-security-policy'] );
+		}, 0 );
+	}
+
 	add_filter( 'script_loader_tag', __NAMESPACE__ . '\\output_integrity_for_script', 0, 2 );
 	add_filter( 'style_loader_tag', __NAMESPACE__ . '\\output_integrity_for_style', 0, 3 );
 	add_action( 'template_redirect', __NAMESPACE__ . '\\send_normal_csp_header' );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,12 @@
+<phpunit bootstrap="tests/bootstrap.php">
+	<testsuites>
+			<testsuite name="BrowserSecurity">
+					<directory prefix="class-test-" suffix=".php">tests</directory>
+			</testsuite>
+	</testsuites>
+	<filter>
+		<whitelist>
+			<directory suffix=".php">inc/</directory>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Altis\Security\Browser;
+
+require __DIR__ . '/class-output.php';
+require '/wp-phpunit/includes/functions.php';
+require '/wp-phpunit/includes/bootstrap.php';

--- a/tests/class-output.php
+++ b/tests/class-output.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Intercept header() calls by defining a header() method within the plugin's
+ * own namespace, to permit inspecting output without sending real headers.
+ *
+ * Hat-tip https://mwop.net/blog/2014-08-11-testing-output-generating-code.html
+ */
+
+namespace Altis\Security\Browser;
+
+/**
+ * Store 
+ */
+abstract class Output {
+    public static $headers = [];
+
+    public static function reset() {
+        self::$headers = [];
+    }
+}
+
+// Force headers_sent to always return false, to obviate process isolation.
+function headers_sent() {
+    return false;
+}
+
+// Redefine header() to push the provided value into our output array.
+function header( $value ) {
+    Output::$headers[] = $value;
+}

--- a/tests/class-test-content-security-policies.php
+++ b/tests/class-test-content-security-policies.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Altis\Security\Browser;
+
+use WP_UnitTestCase;
+
+class Test_Content_Security_Policies extends WP_UnitTestCase {
+	public function setUp() {
+		Output::reset();
+	}
+
+	/**
+	 * Filter the browser security module CSP hook.
+	 *
+	 * @param string[] $policies Map from directive name to value or list of values.
+	 * @return array Filtered array.
+	 */
+	public function _filter_policies( array $policies ) : array {
+		$policies['object-src'] = 'none';
+		$policies['font-src'] = [
+			'https://fonts.gstatic.com',
+			'https://cdnjs.cloudflare.com',
+		];
+		return $policies;
+	}
+
+	public function test_csp_header_empty_by_default() {
+		send_normal_csp_header();
+		$this->assertEquals( [], Output::$headers );
+	}
+
+	public function test_report_only_csp_header_empty_by_default() {
+		send_report_only_csp_header();
+		$this->assertEquals( [], Output::$headers );
+	}
+
+	public function test_filter_csp_policies() {
+		add_filter(
+			'altis.security.browser.content_security_policies',
+			[ $this, '_filter_policies' ]
+		);
+		send_normal_csp_header();
+		$this->assertCount( 1, Output::$headers );
+		$this->assertEquals(
+			"Content-Security-Policy: font-src https://fonts.gstatic.com https://cdnjs.cloudflare.com; object-src 'none'",
+			Output::$headers[0]
+		);
+	}
+
+	public function test_filter_report_only_csp_policies() {
+		add_filter(
+			'altis.security.browser.report_only_content_security_policies',
+			[ $this, '_filter_policies' ]
+		);
+		send_report_only_csp_header();
+		$this->assertCount( 1, Output::$headers );
+		$this->assertEquals(
+			"Content-Security-Policy-Report-Only: font-src https://fonts.gstatic.com https://cdnjs.cloudflare.com; object-src 'none'",
+			Output::$headers[0]
+		);
+	}
+
+	public function test_filter_individual_report_only_directive() {
+		add_filter(
+			'altis.security.browser.filter_report_only_policy_value.object-src',
+			function( $directive ) {
+				return 'none';
+			}
+		);
+		send_report_only_csp_header();
+		$this->assertCount( 1, Output::$headers );
+		$this->assertEquals(
+			"Content-Security-Policy-Report-Only: object-src 'none'",
+			Output::$headers[0]
+		);
+	}
+}

--- a/tests/class-test-content-security-policies.php
+++ b/tests/class-test-content-security-policies.php
@@ -5,8 +5,19 @@ namespace Altis\Security\Browser;
 use WP_UnitTestCase;
 
 class Test_Content_Security_Policies extends WP_UnitTestCase {
-	public function setUp() {
+	function setUp() {
 		Output::reset();
+		parent::setUp();
+	}
+
+	function test_csp_header_empty_by_default() {
+		send_normal_csp_header();
+		$this->assertEquals( [], Output::$headers );
+	}
+
+	function test_report_only_csp_header_empty_by_default() {
+		send_report_only_csp_header();
+		$this->assertEquals( [], Output::$headers );
 	}
 
 	/**
@@ -15,7 +26,7 @@ class Test_Content_Security_Policies extends WP_UnitTestCase {
 	 * @param string[] $policies Map from directive name to value or list of values.
 	 * @return array Filtered array.
 	 */
-	public function _filter_policies( array $policies ) : array {
+	function _filter_policies( array $policies ) : array {
 		$policies['object-src'] = 'none';
 		$policies['font-src'] = [
 			'https://fonts.gstatic.com',
@@ -24,54 +35,59 @@ class Test_Content_Security_Policies extends WP_UnitTestCase {
 		return $policies;
 	}
 
-	public function test_csp_header_empty_by_default() {
+	function test_filter_csp_policies() {
+		$filter_name = 'altis.security.browser.content_security_policies';
+		add_filter( $filter_name, [ $this, '_filter_policies' ] );
 		send_normal_csp_header();
-		$this->assertEquals( [], Output::$headers );
+		$this->assertEquals(
+			[ "Content-Security-Policy: font-src https://fonts.gstatic.com https://cdnjs.cloudflare.com; object-src 'none'" ],
+			Output::$headers
+		);
 	}
 
-	public function test_report_only_csp_header_empty_by_default() {
+	function test_filter_report_only_csp_policies() {
+		$filter_name = 'altis.security.browser.report_only_content_security_policies';
+		add_filter( $filter_name, [ $this, '_filter_policies' ] );
 		send_report_only_csp_header();
-		$this->assertEquals( [], Output::$headers );
+		$this->assertEquals(
+			[ "Content-Security-Policy-Report-Only: font-src https://fonts.gstatic.com https://cdnjs.cloudflare.com; object-src 'none'" ],
+			Output::$headers
+		);
 	}
 
-	public function test_filter_csp_policies() {
+	/**
+	 * Filter the filter_policy_value.child-src hook.
+	 *
+	 * @param array $value An array of directive values (may be empty).
+	 * @return array The filtered array of directive values.
+	 */
+	function _filter_child_src_policy_value( array $directive ) : array {
+		return [
+			"'self'",
+		];
+	}
+
+	function test_filter_individual_directive() {
 		add_filter(
-			'altis.security.browser.content_security_policies',
-			[ $this, '_filter_policies' ]
+			'altis.security.browser.filter_policy_value.child-src',
+			[ $this, '_filter_child_src_policy_value' ]
 		);
 		send_normal_csp_header();
-		$this->assertCount( 1, Output::$headers );
 		$this->assertEquals(
-			"Content-Security-Policy: font-src https://fonts.gstatic.com https://cdnjs.cloudflare.com; object-src 'none'",
-			Output::$headers[0]
+			[ "Content-Security-Policy: child-src 'self'" ],
+			Output::$headers
 		);
 	}
 
-	public function test_filter_report_only_csp_policies() {
+	function test_filter_individual_report_only_directive() {
 		add_filter(
-			'altis.security.browser.report_only_content_security_policies',
-			[ $this, '_filter_policies' ]
+			'altis.security.browser.filter_report_only_policy_value.child-src',
+			[ $this, '_filter_child_src_policy_value' ]
 		);
 		send_report_only_csp_header();
-		$this->assertCount( 1, Output::$headers );
 		$this->assertEquals(
-			"Content-Security-Policy-Report-Only: font-src https://fonts.gstatic.com https://cdnjs.cloudflare.com; object-src 'none'",
-			Output::$headers[0]
-		);
-	}
-
-	public function test_filter_individual_report_only_directive() {
-		add_filter(
-			'altis.security.browser.filter_report_only_policy_value.object-src',
-			function( $directive ) {
-				return 'none';
-			}
-		);
-		send_report_only_csp_header();
-		$this->assertCount( 1, Output::$headers );
-		$this->assertEquals(
-			"Content-Security-Policy-Report-Only: object-src 'none'",
-			Output::$headers[0]
+			[ "Content-Security-Policy-Report-Only: child-src 'self'" ],
+			Output::$headers
 		);
 	}
 }


### PR DESCRIPTION
This starts the implementation of report-only content security policies, discussed and tracked in #6. As decided there we are introducing a parallel set of filters.

Remaining todos:

- [x] Allow filtering report-only values separately from normal CSP filter values
    - Do we introduce a new `altis.security.browser.filter_report_only_policy_value` filter, or do we add a `$report_only` boolean argument to that filter?
- [x] What else is needed... :thinking: 