### PR TITLE
Enable HSTS by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ In some cases, you may want to adjust or disable these headers depending on the 
 
 The [`Strict-Transport-Security` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) (sometimes called HSTS) is used to enforce HTTPS (TLS/SSL) connections when loading a site and can be used to enhance the site's security.
 
-By default, Altis does not enable HSTS. You can set the value of this header manually by defining the `ABS_HSTS` constant:
+By default, Altis adds a `Strict-Transport-Security` header if your site is served over HTTPS, with the value set to `max-age=86400` (one day). If you want to override this value (such as for longer durations, or to specify `includeSubdomains`), you can define the `ABS_HSTS` constant:
 
 ```php
 define( 'ABS_HSTS', 'max-age=31536000; includeSubDomains' );

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ In some cases, you may want to adjust or disable these headers depending on the 
 
 The [`Strict-Transport-Security` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) (sometimes called HSTS) is used to enforce HTTPS (TLS/SSL) connections when loading a site and can be used to enhance the site's security.
 
-By default, Altis adds a `Strict-Transport-Security` header if your site is served over HTTPS, with the value set to `max-age=86400` (one day). If you want to override this value (such as for longer durations, or to specify `includeSubdomains`), you can define the `ABS_HSTS` constant:
+By default, Altis does not enable HSTS. You can set the value of this header manually by defining the `ABS_HSTS` constant:
 
 ```php
 define( 'ABS_HSTS', 'max-age=31536000; includeSubDomains' );

--- a/README.md
+++ b/README.md
@@ -136,6 +136,23 @@ This plugin automatically adds various security headers by default. These follow
 In some cases, you may want to adjust or disable these headers depending on the use cases of your site.
 
 
+#### Strict-Transport-Security
+
+The [`Strict-Transport-Security` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) (sometimes called HSTS) is used to enforce HTTPS (TLS/SSL) connections when loading a site and can be used to enhance the site's security.
+
+By default, Altis adds a `Strict-Transport-Security` header if your site is served over HTTPS, with the value set to `max-age=86400` (one day). If you want to override this value (such as for longer durations, or to specify `includeSubdomains`), you can define the `ABS_HSTS` constant:
+
+```php
+define( 'ABS_HSTS', 'max-age=31536000; includeSubDomains' );
+```
+
+To disable the automatic behaviour entirely, set the constant to `false`:
+
+```php
+define( 'ABS_HSTS', false );
+```
+
+
 #### X-Content-Type-Options
 
 By default, Altis adds a [`X-Content-Type-Options` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options) with the value set to `nosniff`. This prevents browsers from attempting to guess the content type based on the content, and instead forces them to follow the type set in the `Content-Type` header.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -47,7 +47,7 @@ function bootstrap( array $config ) {
 		}, 0 );
 	}
 
-	$use_hsts = $config['strict-transport-security'] ?? false;
+	$use_hsts = $config['strict-transport-security'] ?? null;
 
 	// Default to on for HTTPS sites.
 	if ( $use_hsts === null ) {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -47,7 +47,7 @@ function bootstrap( array $config ) {
 		}, 0 );
 	}
 
-	$use_hsts = $config['strict-transport-security'] ?? null;
+	$use_hsts = $config['strict-transport-security'] ?? false;
 
 	// Default to on for HTTPS sites.
 	if ( $use_hsts === null ) {

--- a/plugin.php
+++ b/plugin.php
@@ -17,5 +17,6 @@ bootstrap( [
 	'automatic-integrity' => defined( 'ABS_AUTOMATIC_INTEGRITY' ) ? ABS_AUTOMATIC_INTEGRITY : true,
 	'nosniff-header' => defined( 'ABS_NOSNIFF_HEADER' ) ? ABS_NOSNIFF_HEADER : true,
 	'frame-options-header' => defined( 'ABS_FRAME_OPTIONS_HEADER' ) ? ABS_FRAME_OPTIONS_HEADER : true,
-	'xss-protection-header' => defined( 'ABS_XSS_PROTECTION_HEADER' ) ? ABS_XSS_PROTECTION_HEADER :true,
+	'strict-transport-security' => defined( 'ABS_HSTS' ) ? ABS_HSTS : null,
+	'xss-protection-header' => defined( 'ABS_XSS_PROTECTION_HEADER' ) ? ABS_XSS_PROTECTION_HEADER : true,
 ] );

--- a/plugin.php
+++ b/plugin.php
@@ -17,6 +17,6 @@ bootstrap( [
 	'automatic-integrity' => defined( 'ABS_AUTOMATIC_INTEGRITY' ) ? ABS_AUTOMATIC_INTEGRITY : true,
 	'nosniff-header' => defined( 'ABS_NOSNIFF_HEADER' ) ? ABS_NOSNIFF_HEADER : true,
 	'frame-options-header' => defined( 'ABS_FRAME_OPTIONS_HEADER' ) ? ABS_FRAME_OPTIONS_HEADER : true,
-	'strict-transport-security' => defined( 'ABS_HSTS' ) ? ABS_HSTS : false,
+	'strict-transport-security' => defined( 'ABS_HSTS' ) ? ABS_HSTS : null,
 	'xss-protection-header' => defined( 'ABS_XSS_PROTECTION_HEADER' ) ? ABS_XSS_PROTECTION_HEADER : true,
 ] );

--- a/plugin.php
+++ b/plugin.php
@@ -17,6 +17,6 @@ bootstrap( [
 	'automatic-integrity' => defined( 'ABS_AUTOMATIC_INTEGRITY' ) ? ABS_AUTOMATIC_INTEGRITY : true,
 	'nosniff-header' => defined( 'ABS_NOSNIFF_HEADER' ) ? ABS_NOSNIFF_HEADER : true,
 	'frame-options-header' => defined( 'ABS_FRAME_OPTIONS_HEADER' ) ? ABS_FRAME_OPTIONS_HEADER : true,
-	'strict-transport-security' => defined( 'ABS_HSTS' ) ? ABS_HSTS : null,
+	'strict-transport-security' => defined( 'ABS_HSTS' ) ? ABS_HSTS : false,
 	'xss-protection-header' => defined( 'ABS_XSS_PROTECTION_HEADER' ) ? ABS_XSS_PROTECTION_HEADER : true,
 ] );


### PR DESCRIPTION
Follow on from #17 to enable HSTS by default. Separated from that to allow us to do minor vs major releases for the default change.

(Currently this PR includes all of #17 but should clean itself up after that's merged.)