### PR TITLE
Correct header name for HSTS

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -393,7 +393,7 @@ function send_hsts_header( $value ) {
 		$value = 'max-age=86400';
 	}
 
-	header( sprintf( 'Strict-Transport-Policy: %s', $value ) );
+	header( sprintf( 'Strict-Transport-Security: %s', $value ) );
 }
 
 /**


### PR DESCRIPTION
Unfortunately our HSTS support has been using the wrong header name.