### PR TITLE
Send HSTS on all pages

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -55,7 +55,13 @@ function bootstrap( array $config ) {
 		$use_hsts = is_ssl();
 	}
 	if ( $use_hsts ) {
-		add_action( 'template_redirect', function () use ( $use_hsts ) {
+		add_action( 'parse_request', function () use ( $use_hsts ) {
+			send_hsts_header( $use_hsts );
+		}, -1000 );
+		add_action( 'admin_init', function () use ( $use_hsts ) {
+			send_hsts_header( $use_hsts );
+		} );
+		add_action( 'login_init', function () use ( $use_hsts ) {
 			send_hsts_header( $use_hsts );
 		} );
 	}


### PR DESCRIPTION
This changes from template_redirect, which only applies to frontend pages, to being active on all pages served through all entrypoints. The frontend and API are handled through parse_request (which is fired during permalink resolution), and admin/login are fired separately.

Fixes #26.