### PR TITLE
Use default version for hash generation if not set

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -232,13 +232,13 @@ function generate_hash_for_asset( WP_Dependencies $dependencies, string $handle 
 
 	// Determine version with default version following same logic as core WP_Scripts and WP_Styles. 
 	if ( null === $asset->ver ) {
-		$ver = '';
+		$version = '';
 	} else {
-		$ver = $asset->ver ? $asset->ver : $dependencies->default_version;
+		$version = $asset->ver ? $asset->ver : $dependencies->default_version;
 	}
 
 	// Generate the hash.
-	$hash = generate_hash_for_path( $actual_path, $ver );
+	$hash = generate_hash_for_path( $actual_path, $version );
 
 	if ( empty( $hash ) ) {
 		// Couldn't generate a hash.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -231,7 +231,7 @@ function generate_hash_for_asset( WP_Dependencies $dependencies, string $handle 
 	}
 
 	// Generate the hash.
-	$hash = generate_hash_for_path( $actual_path, $asset->ver );
+	$hash = generate_hash_for_path( $actual_path, $asset->ver ?: $dependencies->default_version );
 	if ( empty( $hash ) ) {
 		// Couldn't generate a hash.
 		return new WP_Error(

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -234,7 +234,7 @@ function generate_hash_for_asset( WP_Dependencies $dependencies, string $handle 
 	if ( null === $asset->ver ) {
 		$version = '';
 	} else {
-		$version = $asset->ver ? $asset->ver : $dependencies->default_version;
+		$version = $asset->ver ?: $dependencies->default_version;
 	}
 
 	// Generate the hash.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -230,8 +230,16 @@ function generate_hash_for_asset( WP_Dependencies $dependencies, string $handle 
 		);
 	}
 
+	// Determine version with default version following same logic as core WP_Scripts and WP_Styles. 
+	if ( null === $asset->ver ) {
+		$ver = '';
+	} else {
+		$ver = $asset->ver ? $asset->ver : $dependencies->default_version;
+	}
+
 	// Generate the hash.
-	$hash = generate_hash_for_path( $actual_path, $asset->ver ?: $dependencies->default_version );
+	$hash = generate_hash_for_path( $actual_path, $ver );
+
 	if ( empty( $hash ) ) {
 		// Couldn't generate a hash.
 		return new WP_Error(


### PR DESCRIPTION
I've been running into a bug: for a _block theme_, the core block styles fail to load after updating WordPress as the integrity hash check fails. This is despite the version no appended to the src changing. Clearing CDN cache doesn't solve the problem. 

This affects core block styles like: 

```
/wp-includes/blocks/navigation/style.min.css
/wp-includes/blocks/cover/style.min.css
/wp-includes/blocks/social-links/style.min.css
/wp-includes/blocks/image/style.min.css
```

[This is because - for core blocks, no version is provided at the point the styles are registered. The version in block metadata is not used and it is hardcoded to false.](https://github.com/WordPress/WordPress/blob/9d235f6c2d41e5d0f5a6b1a80d5ebd5673d09f0c/wp-includes/blocks.php#L350) Note that assets without versions do default to the current WordPress version number [however this is only done at the point the tag is output.](https://github.com/WordPress/WordPress/blob/9d235f6c2d41e5d0f5a6b1a80d5ebd5673d09f0c/wp-includes/class-wp-styles.php#L150)

I think the best fix for this is, to use the the default version when calculating the cache key if no version is explicitly provided. 