### PR TITLE
Fix integrity hash not rendering due to quote mismatch

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -351,14 +351,15 @@ function output_integrity_for_script( string $tag, string $handle ) : string {
 		return $tag;
 	}
 
-	// Insert the attribute.
-	$tag = str_replace(
-		" src='",
+	// Insert the attribute, handling both single and double quotes.
+	$tag = preg_replace(
+		'/( src=)([\'"])/',
 		sprintf(
-			" integrity='%s' src='",
+			' integrity=$2%s$2$1$2',
 			esc_attr( $hash )
 		),
-		$tag
+		$tag,
+		1
 	);
 	return $tag;
 }
@@ -379,14 +380,15 @@ function output_integrity_for_style( string $html, string $handle ) : string {
 		return $html;
 	}
 
-	// Insert the attribute.
-	$html = str_replace(
-		" href='",
+	// Insert the attribute, handling both single and double quotes.
+	$html = preg_replace(
+		'/( href=)([\'"])/',
 		sprintf(
-			" integrity='%s' href='",
+			' integrity=$2%s$2$1$2',
 			esc_attr( $hash )
 		),
-		$html
+		$html,
+		1
 	);
 	return $html;
 }


### PR DESCRIPTION
## Problem

The `output_integrity_for_script()` and `output_integrity_for_style()` functions use `str_replace()` looking for single-quoted attributes (`src='` and `href='`), but WordPress core and plugins may output script/style tags with double quotes.

This causes the integrity hash to be generated but never rendered in the HTML output.

## Solution

Replace `str_replace()` with `preg_replace()` using a pattern that captures the quote character (`['"]`) and reuses it in the replacement string. This supports both single and double quote styles.

### Before
```php
$tag = str_replace(
    " src='",
    sprintf( " integrity='%s' src='", esc_attr( $hash ) ),
    $tag
);
```

### After
```php
$tag = preg_replace(
    '/( src=)(['\''"])/',
    sprintf( ' integrity=$2%s$2$1$2', esc_attr( $hash ) ),
    $tag,
    1
);
```

## Testing

1. Enqueue a script with a local URL
2. Verify the integrity attribute is added regardless of whether the tag uses single or double quotes