### PR TITLE
Add `: void` return type to test setUp() methods

### DIFF
--- a/tests/class-test-content-security-policies.php
+++ b/tests/class-test-content-security-policies.php
@@ -5,7 +5,7 @@ namespace Altis\Security\Browser;
 use WP_UnitTestCase;
 
 class Test_Content_Security_Policies extends WP_UnitTestCase {
-	function setUp() {
+	function setUp(): void {
 		Output::reset();
 		parent::setUp();
 	}

--- a/tests/class-test-rest-allow-origins.php
+++ b/tests/class-test-rest-allow-origins.php
@@ -7,7 +7,7 @@ use WP_REST_Request;
 
 class Test_Rest_Allow_Origins extends WP_UnitTestCase {
 
-	function setUp() {
+	function setUp(): void {
 		parent::setUp();
 	}
 


### PR DESCRIPTION
PHPUnit 8+ and PHPUnitPolyfills declare `TestCase::setUp(): void`; subclass overrides without the matching return type fatal under LSP.

Currently breaks nightly cross-version tests in humanmade/product-dev with:

\`\`\`
Fatal error: Declaration of Altis\Security\Browser\Test_Content_Security_Policies::setUp()
must be compatible with Yoast\PHPUnitPolyfills\TestCases\TestCase::setUp(): void
\`\`\`

Touches `tests/class-test-content-security-policies.php` and `tests/class-test-rest-allow-origins.php`. PHP 7.1+ compatible (matches module floor).